### PR TITLE
Xcrun addition

### DIFF
--- a/src/Cake.AppleSimulator.Tests/Fixtures/XCRunFindSImCrlFxture.cs
+++ b/src/Cake.AppleSimulator.Tests/Fixtures/XCRunFindSImCrlFxture.cs
@@ -1,0 +1,15 @@
+﻿using Cake.AppleSimulator.XCRun;
+
+namespace Cake.AppleSimulator.Tests.Fixtures
+{
+    internal sealed class XCRunFindSimCtlFixture : XCRunFixture<XCRunSettings>
+    {
+        public string ToolResult { get; set; }
+
+        protected override void RunTool()
+        {
+            var runner = new XCRunRunner(FileSystem, Environment, ProcessRunner, Tools, Log, Settings);
+            ToolResult = runner.Find("simctl");
+        }
+    }
+}

--- a/src/Cake.AppleSimulator.Tests/Fixtures/XCRunFixture.cs
+++ b/src/Cake.AppleSimulator.Tests/Fixtures/XCRunFixture.cs
@@ -1,0 +1,25 @@
+﻿using Cake.AppleSimulator.XCRun;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Testing.Fixtures;
+using NSubstitute;
+
+namespace Cake.AppleSimulator.Tests.Fixtures
+{
+    internal abstract class XCRunFixture<TSettings> : ToolFixture<TSettings, ToolFixtureResult>
+		where TSettings : XCRunSettings, new()
+	{
+		protected XCRunFixture() : base("xcrun")
+		{
+			Log = Substitute.For<ICakeLog>();
+			ProcessRunner.Process.SetStandardOutput(new string[] { });
+		}
+
+		public ICakeLog Log { get; private set; }
+
+		protected override ToolFixtureResult CreateResult(FilePath path, ProcessSettings process)
+		{
+			return new ToolFixtureResult(path, process);
+		}
+	}
+}

--- a/src/Cake.AppleSimulator.Tests/Unit/XCRunTests.cs
+++ b/src/Cake.AppleSimulator.Tests/Unit/XCRunTests.cs
@@ -1,0 +1,66 @@
+﻿using Cake.AppleSimulator.Tests.Fixtures;
+using Cake.Core;
+using Cake.Testing;
+using FluentAssertions;
+using Xunit;
+
+namespace Cake.AppleSimulator.Tests.Unit
+{
+    public class XCRunTests
+    {
+        [Fact]
+        public void Should_Find_AppleSimulator_If_Tool_Path_Not_Provided()
+        {
+            // Given
+            var fixture = new XCRunFindSimCtlFixture();
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal("/Working/tools/xcrun", result.Path.FullPath);
+        }
+
+        [Fact]
+        public void Should_Throw_If_Has_A_Non_Zero_Exit_Code()
+        {
+            // Given
+            var fixture = new XCRunFindSimCtlFixture();
+            fixture.GivenProcessExitsWithCode(72);
+
+            // When
+            fixture.Invoking(x => x.Run())
+                // Then
+                .ShouldThrow<CakeException>()
+                .WithMessage("XcodeRun: Process returned an error (exit code 72).");
+        }
+
+        [Fact]
+        public void Should_Throw_If_Does_Not_Exist()
+        {
+            // Given
+            var fixture = new XCRunFindSimCtlFixture();
+            fixture.GivenSettingsToolPathExist();
+
+            // When
+            fixture.Invoking(x => x.Run())
+               // Then
+               .ShouldNotThrow<CakeException>();
+        }
+
+        [Theory]
+        [InlineData("/usr/local/bin/xcrun", "/usr/local/bin/xcrun")]
+        public void Should_Use_XCRun_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
+        {
+            // Given
+            var fixture = new XCRunFindSimCtlFixture { Settings = { ToolPath = toolPath } };
+            fixture.GivenSettingsToolPathExist();
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            result.Path.FullPath.Should().Be(expected);
+        }
+    }
+}

--- a/src/Cake.AppleSimulator/XCRun/XCRunCtlRunner.cs
+++ b/src/Cake.AppleSimulator/XCRun/XCRunCtlRunner.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.IO;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.AppleSimulator.XCRun
+{
+    internal sealed class XCRunRunner : XCRunTool<XCRunSettings>
+    {
+        private readonly ICakeLog _log;
+
+        public XCRunRunner(IFileSystem fileSystem, ICakeEnvironment environment, IProcessRunner processRunner,
+            IToolLocator tools, ICakeLog log, XCRunSettings settings) : base(fileSystem, environment, processRunner, tools, settings)
+        {
+            _log = log;
+        }
+
+        public string Find(string command)
+        {
+            var arguments = CreateArgumentBuilder(Settings).Append("--find").Append(command);
+
+            var stdOutput = RunAndRedirectStandardOutput(Settings, arguments);
+            if (stdOutput.StartsWith("xcrun: error:", StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new FileNotFoundException();
+            }
+            return stdOutput;
+        }
+    }
+}

--- a/src/Cake.AppleSimulator/XCRun/XCRunSettings.cs
+++ b/src/Cake.AppleSimulator/XCRun/XCRunSettings.cs
@@ -1,0 +1,8 @@
+using Cake.Core.Tooling;
+
+namespace Cake.AppleSimulator.XCRun
+{
+    public class XCRunSettings : ToolSettings
+    {
+    }
+}

--- a/src/Cake.AppleSimulator/XCRun/XCRunTool.cs
+++ b/src/Cake.AppleSimulator/XCRun/XCRunTool.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+
+namespace Cake.AppleSimulator.XCRun
+{
+	public abstract class XCRunTool<TSettings> : Tool<TSettings> where TSettings : XCRunSettings
+	{
+		/// <summary>
+		///     Initializes a new instance of the <see cref="XCRunTool{TSettings}" /> class.
+		/// </summary>
+		/// <param name="fileSystem">The file system.</param>
+		/// <param name="environment">The environment.</param>
+		/// <param name="processRunner">The process runner.</param>
+		/// <param name="tools">The tool locator.</param>
+		/// <param name="settings">The Settings.</param>
+		protected XCRunTool(
+			IFileSystem fileSystem,
+			ICakeEnvironment environment,
+			IProcessRunner processRunner,
+			IToolLocator tools, TSettings settings)
+				: base(fileSystem, environment, processRunner, tools)
+		{
+			Settings = settings;
+		}
+
+		protected TSettings Settings { get; set; }
+
+		/// <summary>
+		///     Creates a <see cref="ProcessArgumentBuilder" /> and adds common commandline arguments.
+		/// </summary>
+		/// <param name="settings">The Settings.</param>
+		/// <returns>Instance of <see cref="ProcessArgumentBuilder" />.</returns>
+		protected ProcessArgumentBuilder CreateArgumentBuilder(TSettings settings)
+		{
+			if (settings == null)
+			{
+				throw new ArgumentNullException(nameof(settings));
+			}
+
+			var builder = new ProcessArgumentBuilder();
+			return builder;
+		}
+
+		/// <summary>
+		///     Gets alternative file paths which the tool may exist in
+		/// </summary>
+		/// <returns>The alternative locations for the tool.</returns>
+		protected override IEnumerable<FilePath> GetAlternativeToolPaths(TSettings settings)
+		{
+			return new[] { new FilePath("/usr/bin/xcrun") };
+		}
+
+		/// <summary>
+		///     Gets the possible names of the tool executable.
+		/// </summary>
+		/// <returns>The tool executable name.</returns>
+		protected override IEnumerable<string> GetToolExecutableNames()
+		{
+			return new[]
+			{
+				"xcrun"
+			};
+		}
+
+		/// <summary>
+		///     Gets the name of the tool.
+		/// </summary>
+		/// <returns>The name of the tool.</returns>
+		protected override string GetToolName()
+		{
+			return "XcodeRun";
+		}
+
+		/// <summary>
+		///     Runs the specified process, using the specified Settings/arguments and returns the process StandardOutput.
+		/// </summary>
+		/// <param name="settings">The Settings.</param>
+		/// <param name="arguments">The arguments.</param>
+		protected string RunAndRedirectStandardOutput(TSettings settings, ProcessArgumentBuilder arguments)
+		{
+			var stdOutput = string.Empty;
+
+			Run(settings, arguments,
+				new ProcessSettings
+				{
+					RedirectStandardOutput = true
+				},
+				process => stdOutput = string.Join(Environment.NewLine, process.GetStandardOutput()));
+
+			return stdOutput;
+		}
+	}
+}


### PR DESCRIPTION
Add `xcrun` in order to find where the Xcode tools are when multiple copies of Xcode are installed.